### PR TITLE
Adds parentheses around division in stylus padding calculation

### DIFF
--- a/stylus/_buttons.styl
+++ b/stylus/_buttons.styl
@@ -1,6 +1,6 @@
 $btn--base
   @extend .brdr--rounded
-  padding: $padding / 2 $padding
+  padding: ($padding / 2) $padding
   border: 2px solid #ccc
   color: $font-color
   text-decoration: none


### PR DESCRIPTION
Without it, the css for buttons starts to propagate $padding as a value string and a chain of fail ensues.