### PR TITLE
Fix .btn background on <button>

### DIFF
--- a/scss/_buttons.scss
+++ b/scss/_buttons.scss
@@ -5,6 +5,7 @@
   color: $font-color;
   text-decoration: none;
   text-align: center;
+  background: transparent;
 }
 
 .btn {

--- a/stylus/_buttons.styl
+++ b/stylus/_buttons.styl
@@ -5,6 +5,7 @@ $btn--base
   color: $font-color
   text-decoration: none
   text-align: center
+  background: transparent
 .btn
   @extend $btn--base
   &:hover,


### PR DESCRIPTION
Clear browser default background off buttons for consistency.

Before:
![image](https://cloud.githubusercontent.com/assets/622073/20065961/038af7bc-a521-11e6-850d-cae40b3657de.png)

After:
![image](https://cloud.githubusercontent.com/assets/622073/20065972/124a4906-a521-11e6-8f5b-4ad30ec344e6.png)
